### PR TITLE
fix: concurrent gets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-registry-utils",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
When 2 concurrent gets were coming for a version that was no available
in the already cache meta:
- first request would consider that it had to refresh and could not return
stale meta (so far so good)
- second request would consider that it should not refresh meta (because first
was already doing it) and it could return stale meta
The problem on that second request is that it would then return metas missing the
version it was looking for even though it was in the progress of being fetched
This PR makes it so we store the pending refresh so that the second request
benefits from it
